### PR TITLE
Add ftplugin/astro.vim and autoload/astro.vim

### DIFF
--- a/autoload/astro.vim
+++ b/autoload/astro.vim
@@ -1,0 +1,76 @@
+function! astro#IdentifyScope(start, end) abort
+    let pos_start = searchpairpos(a:start, '', a:end, 'bnW')
+    let pos_end = searchpairpos(a:start, '', a:end, 'nW')
+
+    return pos_start != [0, 0]
+                \ && pos_end != [0, 0]
+                \ && pos_start[0] != getpos('.')[1]
+endfunction
+
+function! astro#AstroComments() abort
+    if astro#IdentifyScope('^---\n\s*\S', '^---\n\n')
+                \ || astro#IdentifyScope('^\s*<script', '^\s*<\/script>')
+        " ECMAScript comments
+        setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
+        setlocal commentstring=//%s
+
+    elseif astro#IdentifyScope('^\s*<style', '^\s*<\/style>')
+        " CSS comments
+        setlocal comments=s1:/*,mb:*,ex:*/
+        setlocal commentstring=/*%s*/
+
+    else
+        " HTML comments
+        setlocal comments=s:<!--,m:\ \ \ \ ,e:-->
+        setlocal commentstring=<!--%s-->
+    endif
+endfunction
+
+" https://code.visualstudio.com/docs/languages/jsconfig
+function! astro#CollectPathsFromConfig() abort
+    let config_json = findfile('tsconfig.json', '.;')
+    if empty(config_json)
+        let config_json = findfile('jsconfig.json', '.;')
+        if empty(config_json)
+            return
+        endif
+    endif
+
+    let paths_from_config = config_json
+                \ ->readfile()
+                \ ->join()
+                \ ->json_decode()
+                \ ->get('compilerOptions', {})
+                \ ->get('paths', {})
+
+    if !empty(paths_from_config)
+        let b:astro_paths = paths_from_config
+                    \ ->map({key, val -> [
+                    \     key->glob2regpat(),
+                    \     val[0]->substitute('\/\*$', '', '')
+                    \   ]})
+                    \ ->values()
+    endif
+
+    let b:undo_ftplugin ..= " | unlet! b:astro_paths"
+endfunction
+
+function! astro#AstroInclude(filename) abort
+    let decorated_filename = a:filename
+                \ ->substitute("^", "@", "")
+
+    let found_path = b:
+                \ ->get("astro_paths", [])
+                \ ->indexof({ key, val -> decorated_filename =~ val[0]})
+
+    if found_path != -1
+        let alias = b:astro_paths[found_path][0]
+        let path  = b:astro_paths[found_path][1]
+                    \ ->substitute('\(\/\)*$', '/', '')
+
+        return decorated_filename
+                    \ ->substitute(alias, path, '')
+    endif
+
+    return a:filename
+endfunction

--- a/ftplugin/astro.vim
+++ b/ftplugin/astro.vim
@@ -1,0 +1,112 @@
+" Vim filetype plugin file
+" Language:     Astro
+" Maintainer:   Romain Lafourcade <romainlafourcade@gmail.com>
+" Last Change:  2022 Dec 5
+
+if exists("b:did_ftplugin")
+    finish
+endif
+let b:did_ftplugin = 1
+
+let s:cpo_save = &cpo
+set cpo-=C
+
+let b:undo_ftplugin = "setlocal"
+            \ .. " formatoptions<"
+            \ .. " path<"
+            \ .. " suffixesadd<"
+            \ .. " matchpairs<"
+            \ .. " comments<"
+            \ .. " commentstring<"
+            \ .. " iskeyword<"
+            \ .. " define<"
+            \ .. " include<"
+            \ .. " includeexpr<"
+
+" Create self-resetting autocommand group
+augroup Astro
+    autocmd!
+augroup END
+
+" Set 'formatoptions' to break comment lines but not other lines,
+" and insert the comment leader when hitting <CR> or using "o".
+setlocal formatoptions-=t
+setlocal formatoptions+=croql
+
+" Remove irrelevant part of 'path'.
+setlocal path-=/usr/include
+
+" Seed 'path' with default directories for :find, gf, etc.
+setlocal path+=src/**
+setlocal path+=public/**
+
+" Help Vim find extension-less filenames
+let &l:suffixesadd =
+            \ ".astro"
+            \ .. ",.js,.jsx,.es,.es6,.cjs,.mjs,.jsm"
+            \ .. ",.json"
+            \ .. ",.scss,.sass,.css"
+            \ .. ",.svelte"
+            \ .. ",.ts,.tsx,.d.ts"
+            \ .. ",.vue"
+
+" From $VIMRUNTIME/ftplugin/html.vim
+setlocal matchpairs+=<:>
+
+" Matchit configuration
+if exists("loaded_matchit")
+    let b:match_ignorecase = 0
+
+    " From $VIMRUNTIME/ftplugin/javascript.vim
+    let b:match_words =
+                \ '\<do\>:\<while\>,'
+                \ .. '<\@<=\([^ \t>/]\+\)\%(\s\+[^>]*\%([^/]>\|$\)\|>\|$\):<\@<=/\1>,'
+                \ .. '<\@<=\%([^ \t>/]\+\)\%(\s\+[^/>]*\|$\):/>'
+
+    " From $VIMRUNTIME/ftplugin/html.vim
+    let b:match_words ..=
+                \ '<!--:-->,'
+                \ .. '<:>,'
+                \ .. '<\@<=[ou]l\>[^>]*\%(>\|$\):<\@<=li\>:<\@<=/[ou]l>,'
+                \ .. '<\@<=dl\>[^>]*\%(>\|$\):<\@<=d[td]\>:<\@<=/dl>,'
+                \ .. '<\@<=\([^/!][^ \t>]*\)[^>]*\%(>\|$\):<\@<=/\1>'
+
+    let b:undo_ftplugin ..= " | unlet! b:match_ignorecase b:match_words"
+endif
+
+" Change what constitutes a word, mainly useful for CSS/SASS
+setlocal iskeyword+=-
+setlocal iskeyword+=$
+setlocal iskeyword+=%
+
+" Define paths/aliases for module resolution
+call astro#CollectPathsFromConfig()
+
+" Find ESM imports
+setlocal include=^\\s*\\(import\\\|import\\s\\+[^\/]\\+from\\)\\s\\+['\"]
+
+" Process aliases if file can't be found
+setlocal includeexpr=astro#AstroInclude(v:fname)
+
+" Set 'define' to a comprehensive value
+" From $VIMRUNTIME/ftplugin/javascript.vim and
+" $VIMRUNTIME/ftplugin/sass.vim
+let &l:define =
+            \ '\(^\s*(*async\s\+function\|(*function\)'
+            \ .. '\|^\s*\(\*\|static\|async\|get\|set\|\i\+\.\)'
+            \ .. '\|^\s*\(\ze\i\+\)\(([^)]*).*{$\|\s*[:=,]\)'
+            \ .. '\|^\s*\(export\s\+\|export\s\+default\s\+\)*\(var\|let\|const\|function\|class\)'
+            \ .. '\|\<as\>'
+            \ .. '\|^\C\v\s*%(\@function|\@mixin|\=)|^\s*%(\$[[:alnum:]-]+:|[%.][:alnum:]-]+\s*%(\{|$))@='
+
+" HTML comments by default
+setlocal comments=s:<!--,m:\ \ \ \ ,e:-->
+setlocal commentstring=<!--%s-->
+
+" Set &comments and &commentstring according to current scope
+autocmd Astro CursorMoved <buffer> call astro#AstroComments()
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: textwidth=78 tabstop=8 shiftwidth=4 softtabstop=4 expandtab


### PR DESCRIPTION
This pull request adds two files: `ftplugin/astro.vim` and `autoload/astro.vim`.

## Overview

`ftplugin/astro.vim` enables/fine-tunes the following features:

- autoformatting and manual formatting, via `formatoptions`,
- project-wide navigation, via `path`, `define`, `include`, `includeexpr`,`suffixesadd`, and `b:astro_paths`,
- matching with `%`, via `matchpairs`, `b:match_ignorecase`, and `b:match_words`,
- keyword definition, via `iskeyword`,
- default HTML comment format, via `comments` and `commentstring`,
- scope-specific comment format, via a `CursorMoved` autocommand.

`autoload/astro.vim` hosts the following support functions:

- `astro#IdentifyScope()` and `astro#Comments()`, define the proper `comments` and `commentstring` for the current scope,
- `astro#CollectPathsFromConfig()`, collects aliases defined in `tsconfig.json` for use in the function below,
- `astro#AstroInclude()`, replaces aliases in filenames for `:find`, `gf`, etc.

## Details

### Project-wide navigation

- `path` is set according to https://docs.astro.build/en/core-concepts/project-structure/#directories-and-files.

  It allows doing `gf` on `"src/components/Foo.astro"`, `"./Foo.astro"`, `"../bar/Baz.astro"` in the front matter. It also allows doing `:find *Foo<Tab>` for the simple cases.

  It also helps resolving includes for include/definition search.

- `suffixesadd` is a mix of all the values found in `$VIMRUNTIME/ftplugin/{javascript,typescript,css,sass,html}.vim`, plus some Astro-specific ones.

  It tells Vim what extensions to try for extension-less filenames. This allows doing `gf` on `<Foo />` in a template for the simple cases.

- `b:astro_paths` is populated by `astro#CollectPathsFromConfig()` with a list of all the aliases defined in `tsconfig.json` or `jsconfig.json`. This is not directly useful for the user but useful for the next option.

- `includeexpr` is executed if the target is not found. It is bound to `astro#AstroInclude()`, which replaces the alias in the filename with the corresponding path.

  So, in addition to the simple cases, it also handles cases like `"@components/Foo.astro"` for `gf`, include/definition search, etc.

- `include` is set to a value that should work for ESM imports like `import Foo from "...`, `import type Foo from "...`, or `import "...`.

  It allows things like `[<C-i>` on a type, etc.

- `define` is set to a value that mixes the default values for JavaScript and SASS.

  It should help locating definitions in local and included files with commands like `[D` or `:dsearch`.

### Scoped comment formats

`astro#Comments()` set `comments` and `commentstring` to the appropriate value for the current scope. The implementation honestly looks like it should be slow but it only takes a couple of milliseconds and I didn't notice any performance issue.

I did this for `tpope/commentary`, which uses `commentstring`.

Note: it only covers SASS/SCSS/CSS, JS/TS, and HTML at the moment.

---

Tested in Vim 9.0.270 and Vim 9.0472 on a Mac.