### PR TITLE
Handle comments in JSONC

### DIFF
--- a/autoload/astro.vim
+++ b/autoload/astro.vim
@@ -40,7 +40,7 @@ function! astro#CollectPathsFromConfig() abort
 
     let paths_from_config = config_json
                 \ ->readfile()
-                \ ->filter({ _, val -> val !~ '^\s*\/\/' })
+                \ ->filter({ _, val -> val =~ '^\s*[\[\]{}"0-9]' })
                 \ ->join()
                 \ ->json_decode()
                 \ ->get('compilerOptions', {})

--- a/autoload/astro.vim
+++ b/autoload/astro.vim
@@ -29,8 +29,10 @@ endfunction
 " https://code.visualstudio.com/docs/languages/jsconfig
 function! astro#CollectPathsFromConfig() abort
     let config_json = findfile('tsconfig.json', '.;')
+
     if empty(config_json)
         let config_json = findfile('jsconfig.json', '.;')
+
         if empty(config_json)
             return
         endif
@@ -38,6 +40,7 @@ function! astro#CollectPathsFromConfig() abort
 
     let paths_from_config = config_json
                 \ ->readfile()
+                \ ->filter({ _, val -> val !~ '^\s*\/\/' })
                 \ ->join()
                 \ ->json_decode()
                 \ ->get('compilerOptions', {})


### PR DESCRIPTION
`tsconfig.json` files are actually JSONC. This commit removes lines like the following before parsing the content as JSON:

```
// some comment
/*
 * foo
 * bar
*/
```

but it doesn't handle inline comments:

```
  "key": "value", // some comment
```